### PR TITLE
Added Destroy Method to Tag View

### DIFF
--- a/rareapi/views/tags.py
+++ b/rareapi/views/tags.py
@@ -2,16 +2,41 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.serializers import ModelSerializer 
 from rest_framework.response import Response
 from rest_framework import status
-from rareapi.models import Tag
+from rareapi.models import Tag, RareUser
 
 
 class TagView(ViewSet):
     """Rare tags view"""
 
     def list(self, request):
+        """Handle GET requests for all tags
+
+        Returns:
+            Response -- JSON serialized array
+        """
         tags = Tag.objects.all().order_by('label')
         serializer = TagSerializer(tags, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single tag
+
+        Returns:
+            Response -- 204, 403, 404, or 500 status
+        """
+        try:
+            tag = Tag.objects.get(pk=pk)
+            if request.user.is_staff:
+                tag.delete()
+                return Response(None, status=status.HTTP_204_NO_CONTENT)
+            else:
+                return Response({"message": "You do not have admin rights"}, status=status.HTTP_403_FORBIDDEN)
+        except Tag.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        
+        except Exception as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            
 
 class TagSerializer(ModelSerializer):
     class Meta:


### PR DESCRIPTION
Added a `destroy` method to Tag View

Supported routes
`/tags/n` Will return an empty body and a status code of 204, 403, 404, or 500

## Steps to test
1. Pull down the ts-tag-destroy branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Change method to DELETE using `http://localhost:8000/tags/n`
5. If you are an admin you should get a 204 status code
```
Token 978afa7b76527cc21d76d7b5430ab77f73aa3bff
```
6. If you are not an admin you should get a 403 status code
```
Token fa2eba9be8282d595c997ee5cd49f2ed31f65bed
```
7. If you use a tag pk that does not exist (eg. 7) you should get a 404 status code
8. If you use the correct route `/tags` but something else incorrect after after then you will receive a 500 status code
    - Examples:
    - `http://localhost:8000/tags`
    - `http://localhost:8000/tags/adgf`