### PR TITLE
Added update & retrieve method to tag view

### DIFF
--- a/rareapi/views/tags.py
+++ b/rareapi/views/tags.py
@@ -18,11 +18,24 @@ class TagView(ViewSet):
         serializer = TagSerializer(tags, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
     
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for a single tag
+
+        Returns:
+            Response -- JSON serialized object
+        """
+        try:
+            tag = Tag.objects.get(pk=pk)
+            serializer = TagSerializer(tag, context={"request": request})
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Tag.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+    
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a single tag
 
         Returns:
-            Response -- 204, 403, 404, or 500 status
+            Response -- empty response body
         """
         try:
             tag = Tag.objects.get(pk=pk)
@@ -41,7 +54,7 @@ class TagView(ViewSet):
         """Handle PUT requests for a single tag
 
         Returns:
-            Response -- 204, 400, 403, or 404 status
+            Response -- JSON serialized object
         """
         try:
             tag = Tag.objects.get(pk=pk)

--- a/rareapi/views/tags.py
+++ b/rareapi/views/tags.py
@@ -36,6 +36,27 @@ class TagView(ViewSet):
         
         except Exception as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        
+    def update(self, request, pk):
+        """Handle PUT requests for a single tag
+
+        Returns:
+            Response -- 204, 400, 403, or 404 status
+        """
+        try:
+            tag = Tag.object.get(pk=pk)
+            if request.user.is_staff:
+                serializer = TagSerializer(data=request.data)
+                if serializer.is_valid():
+                    tag.label = serializer.validated_data["label"]
+                    tag.save()
+
+                    serializer = TagSerializer(tag, context={"request": request})
+                    return Response(None, status=status.HTTP_204_NO_CONTENT)
+                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"message": "You do not have admin rights"}, status=status.HTTP_403_FORBIDDEN)
+        except Tag.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
             
 
 class TagSerializer(ModelSerializer):

--- a/rareapi/views/tags.py
+++ b/rareapi/views/tags.py
@@ -44,7 +44,7 @@ class TagView(ViewSet):
             Response -- 204, 400, 403, or 404 status
         """
         try:
-            tag = Tag.object.get(pk=pk)
+            tag = Tag.objects.get(pk=pk)
             if request.user.is_staff:
                 serializer = TagSerializer(data=request.data)
                 if serializer.is_valid():
@@ -52,7 +52,7 @@ class TagView(ViewSet):
                     tag.save()
 
                     serializer = TagSerializer(tag, context={"request": request})
-                    return Response(None, status=status.HTTP_204_NO_CONTENT)
+                    return Response(serializer.data, status=status.HTTP_204_NO_CONTENT)
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
             return Response({"message": "You do not have admin rights"}, status=status.HTTP_403_FORBIDDEN)
         except Tag.DoesNotExist as ex:


### PR DESCRIPTION
Added an `update` & `retrieve` method to Tag View

Supported routes
`/tags/n` Will return an object of a single tag in the response body for both methods

## Steps to test
### Update Method
1. Pull down the `ts-tag-update` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Change method to PUT using `http://localhost:8000/tags/n`
5. If you are an admin you should get a 204 status code
```
Token 978afa7b76527cc21d76d7b5430ab77f73aa3bff
```
6. The response you get back should have the following properties:
```
{
    "id": 2,
    "label": "tech"
}
```
7. If you are not an admin you should get a 403 status code
```
Token fa2eba9be8282d595c997ee5cd49f2ed31f65bed
```

### Retrieve Method
1. Change method to GET using `http://localhost:8000/tags/n`
2. You should receive a single object with the following properties:
```
{
    "id": 2,
    "label": "tech"
}
```
3. Verify you receive a 200 status code