### PR TITLE
Category View DELETE method

### DIFF
--- a/rareapi/views/categories.py
+++ b/rareapi/views/categories.py
@@ -22,4 +22,23 @@ class CategoryViewSet(viewsets.ViewSet):
 
         serializer = CategorySerializer(category, context={'request': request})
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a singular Category
+
+        Returns:
+            Response -- 204, 403, 404, or 500 status
+        """
+        try:
+            category = Category.objects.get(pk=pk)
+            if request.user.is_staff:
+                category.delete()
+                return Response(None, status=status.HTTP_204_NO_CONTENT)
+            else:
+                return Response({"message": "You don't have admin rights!"}, status=status.HTTP_403_FORBIDDEN)
+        except Category.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        
+        except Exception as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
     


### PR DESCRIPTION
Added a `destroy` method to Category View

Supported routes
`/categories/n` Will return an empty body and a status code of 204, 403, 404, or 500

## Steps to test
1. Pull down the tp-destroy-category branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Change method to DELETE using `http://localhost:8000/categories/n`
5. If you are an admin you should get a 204 status code
```
Token 978afa7b76527cc21d76d7b5430ab77f73aa3bff
```
6. If you are not an admin you should get a 403 status code
```
Token fa2eba9be8282d595c997ee5cd49f2ed31f65bed
```
7. If you use a category pk that does not exist (eg. 6) you should get a 404 status code
8. If you use the correct route `/categories`, but something else is incorrect after, then you will receive a 500 status code
    - Examples:
    - `http://localhost:8000/categoriess`
    - `http://localhost:8000/categories/help-me`