### PR TITLE
Category View - retrieve and update methods

### DIFF
--- a/rareapi/views/categories.py
+++ b/rareapi/views/categories.py
@@ -13,6 +13,19 @@ class CategoryViewSet(viewsets.ViewSet):
         serializer = CategorySerializer(categories, many=True)
         return Response(serializer.data)
     
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for a single tag
+
+        Returns:
+            Response -- JSON serialized object
+        """
+        try:
+            category = Category.objects.get(pk=pk)
+            serializer = CategorySerializer(category, context={"request": request})
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Category.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+    
     def create(self, request):
         label = request.data.get('label')
 

--- a/rareapi/views/categories.py
+++ b/rareapi/views/categories.py
@@ -35,6 +35,22 @@ class CategoryViewSet(viewsets.ViewSet):
 
         serializer = CategorySerializer(category, context={'request': request})
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+    
+    def update(self, request, pk):
+        try:
+            category = Category.objects.get(pk=pk)
+            if request.user.is_staff:
+                serializer = CategorySerializer(data=request.data)
+                if serializer.is_valid():
+                    category.label = serializer.validated_data["label"]
+                    category.save()
+
+                    serializer = CategorySerializer(category, context={'request': request})
+                    return Response(serializer.data, status=status.HTTP_204_NO_CONTENT)
+                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"message": "You don't have admin privileges"}, status=status.HTTP_403_FORBIDDEN)
+        except Category.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a singular Category
@@ -48,7 +64,7 @@ class CategoryViewSet(viewsets.ViewSet):
                 category.delete()
                 return Response(None, status=status.HTTP_204_NO_CONTENT)
             else:
-                return Response({"message": "You don't have admin rights!"}, status=status.HTTP_403_FORBIDDEN)
+                return Response({"message": "You don't have admin rights!"}, status=status.HTTP_403_FORBIDDEN)          
         except Category.DoesNotExist as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
         

--- a/rareapi/views/categories.py
+++ b/rareapi/views/categories.py
@@ -9,7 +9,7 @@ class CategorySerializer(serializers.ModelSerializer):
 
 class CategoryViewSet(viewsets.ViewSet):
     def list(self, request):
-        categories = Category.objects.all()
+        categories = Category.objects.all().order_by("label")
         serializer = CategorySerializer(categories, many=True)
         return Response(serializer.data)
     


### PR DESCRIPTION
Added an `update` & `retrieve` method to Category View

Supported routes
`/categories/n` Will return an object of a single category in the response body for both methods

## Steps to test
### Update Method
1. Pull down the `tp-edit-category` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Change method to PUT using `http://localhost:8000/categories/n` and use the following body:
```
{
    "label": "Something test"
}
```
5. If you are an admin you should get a 204 status code
```
Token 978afa7b76527cc21d76d7b5430ab77f73aa3bff
```
6. The response you get back should have the following properties:
```
{
    "id": 4,
    "label": "Something test"
}
```
7. If you are not an admin you should get a 403 status code
```
Token fa2eba9be8282d595c997ee5cd49f2ed31f65bed
```

### Retrieve Method
1. Change method to GET using `http://localhost:8000/categories/n`
2. You should receive a single object with the following properties:
```
{
    "id": 2,
    "label": "Cooking"
}
```
3. Verify you receive a 200 status code