### PR TITLE
Added comment list method & post retrieve method

### DIFF
--- a/rare/urls.py
+++ b/rare/urls.py
@@ -16,13 +16,13 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
-from rareapi.views import login_user, UserPostView, CategoryViewSet, CommentView, TagView
+from rareapi.views import login_user, PostView, CategoryViewSet, CommentView, TagView
 from rest_framework.routers import DefaultRouter
 
 
 
 router = DefaultRouter(trailing_slash=False)
-router.register(r'posts', UserPostView, 'post')
+router.register(r'posts', PostView, 'post')
 router.register(r'categories', CategoryViewSet, 'category')
 router.register(r"comments", CommentView, "comment")
 router.register(r"tags", TagView, "tag")

--- a/rareapi/views/__init__.py
+++ b/rareapi/views/__init__.py
@@ -1,5 +1,5 @@
 from .auth import login_user
-from .posts import UserPostView
+from .posts import PostView
 from .categories import CategoryViewSet
 from .comments import CommentView
 from .tags import TagView

--- a/rareapi/views/comments.py
+++ b/rareapi/views/comments.py
@@ -5,10 +5,31 @@ from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from rest_framework import status
 from rareapi.models import Post, Comment, RareUser
 from django.contrib.auth.models import User
+from django.http import HttpResponseServerError
 
 
 class CommentView(ViewSet):
     """Rare comments view"""
+
+    def list(self, request):
+        """Handle GET requests for all comments
+
+        Returns:
+            Response -- JSON serialized array
+        """
+        post_id = self.request.query_params.get("post", None)
+
+        try:
+            comments = Comment.objects.all().order_by('created_on')
+            # Format created_on to only have the date before serializing
+            if post_id is not None:
+                comments = Comment.objects.filter(post_id=post_id).order_by('created_on')
+            for comment in comments:
+                comment.created_on = comment.created_on.strftime("%m-%d-%Y")
+            serializer = CommentSerializer(comments, many=True, context={"request": request})
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
 
     def create(self, request):
         """Handle POST operations

--- a/rareapi/views/comments.py
+++ b/rareapi/views/comments.py
@@ -81,8 +81,6 @@ class CommentAuthorSerializer(ModelSerializer):
         model = RareUser
         fields = ("id", "user",)
 
-
-
 class CommentSerializer(ModelSerializer):
     """JSON serializer for comments"""
 

--- a/rareapi/views/posts.py
+++ b/rareapi/views/posts.py
@@ -3,11 +3,13 @@ from rest_framework import serializers, viewsets
 from rest_framework.response import Response
 from .comments import CommentAuthorSerializer
 from .categories import CategorySerializer
+from rest_framework import status
+
 
 # ? serializer to show logged in user's posts
 
 
-class UserPostSerializer(serializers.ModelSerializer):
+class PostSerializer(serializers.ModelSerializer):
 
     rare_user = CommentAuthorSerializer(many=False)
     category = CategorySerializer(many=False)
@@ -15,9 +17,22 @@ class UserPostSerializer(serializers.ModelSerializer):
         model = Post
         fields = ['id', 'title', 'rare_user', 'category', 'publication_date', 'content']
 
-class UserPostView(viewsets.ViewSet):
+class PostView(viewsets.ViewSet):
     def list(self, request):
         #? rare_user__user=request.auth.user starts at rare_user table and joins user table to check user's id pk to authorized user's id
         posts = Post.objects.filter(rare_user__user=request.auth.user).order_by('-publication_date')
-        serializer = UserPostSerializer(posts, many=True, context={'request': request})
+        serializer = PostSerializer(posts, many=True, context={'request': request})
         return Response(serializer.data)
+    
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for a single post
+
+        Returns:
+            Response -- JSON serialized object
+        """
+        try:
+            tag = Post.objects.get(pk=pk)
+            serializer = PostSerializer(tag, context={"request": request})
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Post.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/rareapi/views/tags.py
+++ b/rareapi/views/tags.py
@@ -2,7 +2,7 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.serializers import ModelSerializer 
 from rest_framework.response import Response
 from rest_framework import status
-from rareapi.models import Tag, RareUser
+from rareapi.models import Tag
 
 
 class TagView(ViewSet):


### PR DESCRIPTION
Added an `list` method to Comment View & `retrieve` method to Post View

Supported routes
`/comments?post=n` Will return an array of all the comments for that post
`/posts/n` Will return an object for a single post

## Steps to test
### List Method
1. Pull down the `ts-comment-list-method` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Change method to GET and request `http://localhost:8000/comments?post=n`
5. Use the following token
```
Token 978afa7b76527cc21d76d7b5430ab77f73aa3bff
```
6. The response should be an array of comments with the following properties:
```
[
    {
        "id": 6,
        "is_owner": false,
        "author": {
            "id": 2,
            "user": {
                "id": 2,
                "full_name": "Tristan Phifer"
            }
        },
        "content": "WOAH",
        "created_on": "11-22-2023",
        "post": 1
    },
    ...
]
```
8. Be sure you receive a 200 status code

### Retrieve Method
1. Change method to GET using `http://localhost:8000/posts/n`
2. You should receive a single object with the following properties:
```
{
    "id": 1,
    "title": "Example Post 1",
    "rare_user": {
        "id": 1,
        "user": {
            "id": 1,
            "full_name": "Carrie Belk"
        }
    },
    "category": {
        "id": 1,
        "label": "Lifestyle"
    },
    "publication_date": "2023-11-20",
    "content": "This is the content of Example Post 1."
}
```
3. Verify you receive a 200 status code