### PR TITLE
TagTests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 from .categories_test import CategoryTest
+from .tags_test import TagTest

--- a/tests/tags_test.py
+++ b/tests/tags_test.py
@@ -1,0 +1,30 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+from django.contrib.auth.models import User
+
+class TagTest(APITestCase):
+    fixtures = ['tags', 'users', 'tokens']
+
+    def setUp(self):
+        self.user = User.objects.first()
+        self.user.is_staff = True
+        self.user.save()
+        token = Token.objects.get(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+    def test_create_tag(self):
+        url = "/tags"
+
+        data = {
+            "label": "Test Tag"
+        }
+
+        response = self.client.post(url, data, format='json')
+
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(json_response["label"], "Test Tag")

--- a/tests/tags_test.py
+++ b/tests/tags_test.py
@@ -49,3 +49,12 @@ class TagTest(APITestCase):
 
         response = self.client.get(f"/tags/1")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_tag(self):
+        response = self.client.get(f"/tags/1")
+
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(json_response["label"], "dumb")

--- a/tests/tags_test.py
+++ b/tests/tags_test.py
@@ -28,3 +28,17 @@ class TagTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         self.assertEqual(json_response["label"], "Test Tag")
+
+    def test_update_tag(self):
+        data = {
+            "label": "dumb test"
+        }
+
+        response = self.client.put(f"/tags/1", data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        response = self.client.get(f"/tags/1")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["label"], "dumb test")

--- a/tests/tags_test.py
+++ b/tests/tags_test.py
@@ -42,3 +42,10 @@ class TagTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["label"], "dumb test")
+
+    def test_destroy_tag(self):
+        response = self.client.delete(f"/tags/1")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        response = self.client.get(f"/tags/1")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/tags_test.py
+++ b/tests/tags_test.py
@@ -58,3 +58,13 @@ class TagTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(json_response["label"], "dumb")
+
+    def test_list_tag(self):
+        response = self.client.get(f"/tags")
+
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(json_response[0]["label"], "dumb")
+        self.assertEqual(json_response[1]["label"], "fiction")


### PR DESCRIPTION
Added the ability to test the create, update, destroy, retrieve, and list methods of TagView through test integration

## To Test
1. Pull down `tp-tags-tests` branch
2. Make sure your virtual environment is running
3. In your terminal run the following command:
```
python3 manage.py test tests -v 1
```
4. Be sure you get the following response back
```
Found 12 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
............
----------------------------------------------------------------------
Ran 12 tests in 0.345s

OK
Destroying test database for alias 'default'...
```