### PR TITLE
Added destroy method for posts

### DIFF
--- a/rareapi/views/posts.py
+++ b/rareapi/views/posts.py
@@ -54,4 +54,21 @@ class PostView(viewsets.ViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Post.DoesNotExist as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single post
+
+        Returns:
+            Response -- empty response body
+        """
+        try:
+            post = Post.objects.get(pk=pk)
+            post.delete()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+        except Post.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        
+        except Exception as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 


### PR DESCRIPTION
Added a `destroy` method to Post View

Supported routes
`/posts/n` Will return an empty body and a status code of 204, 404, or 500

## Steps to test
1. Pull down the `ts-destroy-post` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Change method to DELETE using `http://localhost:8000/posts/n`
5. Use the following token or any available token
```
Token 978afa7b76527cc21d76d7b5430ab77f73aa3bff
```

7. You should receive a 204 status if it was successful
8. If you use a post pk that does not exist (eg. 10) you should get a 404 status code
9. If you use the correct route `/posts`, but something else is incorrect after, then you will receive a 500 status code
    - Examples:
    - `http://localhost:8000/postsssss`
    - `http://localhost:8000/posts/help-me`