### PR TITLE
PostTagView and API tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "rare-server",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "rare-server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/rare/urls.py
+++ b/rare/urls.py
@@ -18,7 +18,7 @@ from django.contrib import admin
 from django.urls import include, path
 from rareapi.views import UserViewSet, PostView, CategoryViewSet, CommentView, TagView
 from rest_framework.routers import DefaultRouter
-from rareapi.views import CategoryViewSet, CommentView, TagView, UserViewSet, PostView
+from rareapi.views import CategoryViewSet, CommentView, TagView, UserViewSet, PostView, PostTagView
 
 
 router = DefaultRouter(trailing_slash=False)
@@ -26,6 +26,7 @@ router.register(r'posts', PostView, 'post')
 router.register(r'categories', CategoryViewSet, 'category')
 router.register(r"comments", CommentView, "comment")
 router.register(r"tags", TagView, "tag")
+router.register(r"post_tags", PostTagView, "post_tag")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/rareapi/fixtures/post_tags.json
+++ b/rareapi/fixtures/post_tags.json
@@ -6,5 +6,12 @@
             "post": 1,
             "tag": 2
         }
+    },{
+        "model": "rareapi.posttag",
+        "pk": 2,
+        "fields" : {
+            "post": 2,
+            "tag": 4
+        }
     }
 ]

--- a/rareapi/views/__init__.py
+++ b/rareapi/views/__init__.py
@@ -4,4 +4,5 @@ from .posts import PostView
 from .categories import CategoryViewSet
 from .comments import CommentView
 from .tags import TagView
+from .post_tags import PostTagView
 

--- a/rareapi/views/post_tags.py
+++ b/rareapi/views/post_tags.py
@@ -1,0 +1,22 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.serializers import ModelSerializer
+from rest_framework.response import Response
+from rest_framework import status
+from rareapi.models import Tag, Post, PostTag
+
+class PostTagSerializer(ModelSerializer):
+    class Meta:
+        model = PostTag
+        fields = "__all__"
+
+class PostTagView(ViewSet):
+    """Rare Post Tags view"""
+    def list(self, request):
+        """Handle GET requests for all post tags
+        
+        Returns:
+            Response -- JSON serialized array
+        """
+        post_tags= PostTag.objects.all()
+        serializer = PostTagSerializer(post_tags, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/rareapi/views/post_tags.py
+++ b/rareapi/views/post_tags.py
@@ -20,3 +20,12 @@ class PostTagView(ViewSet):
         post_tags= PostTag.objects.all()
         serializer = PostTagSerializer(post_tags, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    def create(self, request):
+        serializer = PostTagSerializer(data=request.data)
+
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/rareapi/views/post_tags.py
+++ b/rareapi/views/post_tags.py
@@ -3,11 +3,27 @@ from rest_framework.serializers import ModelSerializer
 from rest_framework.response import Response
 from rest_framework import status
 from rareapi.models import Tag, Post, PostTag
+from .posts import PostSerializer
+
+# class PostSerializer(ModelSerializer):
+#     class Meta:
+#         model = Post
+#         fields = ['title']
+
+# class TagSerializer(ModelSerializer):
+#     class Meta:
+#         model = Tag
+#         fields = ['label']
 
 class PostTagSerializer(ModelSerializer):
+
+    # post = PostSerializer(many=False)
+    # tag = TagSerializer(many=False)
+
     class Meta:
         model = PostTag
-        fields = "__all__"
+        fields = ["id", "post", "tag"]
+        # , "post", "tag"
 
 class PostTagView(ViewSet):
     """Rare Post Tags view"""

--- a/rareapi/views/posts.py
+++ b/rareapi/views/posts.py
@@ -1,8 +1,9 @@
-from rareapi.models import Post, PostReaction
+from rareapi.models import Post, PostReaction, Tag
 from rest_framework import serializers, viewsets
 from rest_framework.response import Response
 from .comments import RareUserSerializer
 from .categories import CategorySerializer
+from .tags import TagSerializer
 from rest_framework import status
 from django.utils import timezone
 
@@ -19,9 +20,10 @@ class PostSerializer(serializers.ModelSerializer):
     rare_user = RareUserSerializer(many=False)
     category = CategorySerializer(many=False)
     post_reactions = PostReactionSerializer(many=True, source='postreaction_set')
+    post_tags = TagSerializer(many=True, read_only=True, source='tags')
     class Meta:
         model = Post
-        fields = ['id', 'title', 'rare_user', 'category', 'publication_date', 'content', 'post_reactions', 'approved']
+        fields = ['id', 'title', 'rare_user', 'category', 'publication_date', 'content', 'post_reactions', 'approved', 'post_tags']
 
 class PostView(viewsets.ViewSet):
     def list(self, request):
@@ -47,11 +49,28 @@ class PostView(viewsets.ViewSet):
         Returns:
             Response -- JSON serialized object
         """
+        # try:
+        #     post = Post.objects.get(pk=pk)
+        #     post.publication_date = post.publication_date.strftime("%m-%d-%Y")
+        #     serializer = PostSerializer(post, context={"request": request})
+        #     return Response(serializer.data, status=status.HTTP_200_OK)
+        # except Post.DoesNotExist as ex:
+        #     return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        
         try:
             post = Post.objects.get(pk=pk)
             post.publication_date = post.publication_date.strftime("%m-%d-%Y")
-            serializer = PostSerializer(post, context={"request": request})
-            return Response(serializer.data, status=status.HTTP_200_OK)
+            # Get associated tags for post
+            tags = Tag.objects.filter(posttag__post=post)
+            tag_serializer = TagSerializer(tags, many=True)
+
+            post_serializer = PostSerializer(post, context={"request": request})
+            post_data = post_serializer.data
+            post_data['post_tags'] = tag_serializer.data
+
+            return Response(post_data, status=status.HTTP_200_OK)
         except Post.DoesNotExist as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,3 +2,4 @@ from .categories_test import CategoryTest
 from .tags_test import TagTest
 from .users_test import UserTest
 from .posts_test import PostTest
+from .post_tags_test import PostTagTest

--- a/tests/post_tags_test.py
+++ b/tests/post_tags_test.py
@@ -1,0 +1,10 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+from django.contrib.auth.models import User
+
+class PostTagTest(APITestCase):
+    fixtures = ['tags', 'users', 'posts', 'tokens']
+
+    def setUp(self):

--- a/tests/post_tags_test.py
+++ b/tests/post_tags_test.py
@@ -5,7 +5,7 @@ from rest_framework.authtoken.models import Token
 from django.contrib.auth.models import User
 
 class PostTagTest(APITestCase):
-    fixtures = ['tags', 'users', 'posts', 'tokens']
+    fixtures = ['users', 'rareusers', 'categories', 'post_tags', 'tags', 'posts', 'tokens']
 
     def setUp(self):
         self.user = User.objects.first()
@@ -21,9 +21,25 @@ class PostTagTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(json_response[0]["id"], "1")
-        self.assertEqual(json_response[0]["post_id"], "1")
-        self.assertEqual(json_response[0]["tag_id"], "2")
-        self.assertEqual(json_response[1]["id"], "2")
-        self.assertEqual(json_response[1]["post_id"], "2")
-        self.assertEqual(json_response[1]["tag_id"], "4")
+        # self.assertEqual(json_response[0]["id"], "1")
+        self.assertEqual(json_response[0]["post"], 1)
+        self.assertEqual(json_response[0]["tag"], 2)
+        # self.assertEqual(json_response[1]["id"], "2")
+        self.assertEqual(json_response[1]["post"], 2)
+        self.assertEqual(json_response[1]["tag"], 4)
+
+    def test_create_post_tag(self):
+        url = "/post_tags"
+        data = {
+            "post": 3,
+            "tag": 5
+        }
+
+        response = self.client.post(url, data, format='json')
+
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(json_response["post"], 3)
+        self.assertEqual(json_response["tag"], 5)

--- a/tests/post_tags_test.py
+++ b/tests/post_tags_test.py
@@ -8,3 +8,22 @@ class PostTagTest(APITestCase):
     fixtures = ['tags', 'users', 'posts', 'tokens']
 
     def setUp(self):
+        self.user = User.objects.first()
+        self.user.is_staff = True
+        self.user.save()
+        token = Token.objects.get(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
+    def test_get_all_tags(self):
+        response = self.client.get(f"/post_tags")
+
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(json_response[0]["id"], "1")
+        self.assertEqual(json_response[0]["post_id"], "1")
+        self.assertEqual(json_response[0]["tag_id"], "2")
+        self.assertEqual(json_response[1]["id"], "2")
+        self.assertEqual(json_response[1]["post_id"], "2")
+        self.assertEqual(json_response[1]["tag_id"], "4")

--- a/tests/posts_test.py
+++ b/tests/posts_test.py
@@ -30,7 +30,7 @@ class PostTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Assert that the values are correct
-        keys = {'id', 'title', 'rare_user', 'category', 'publication_date', 'content', 'post_reactions', 'approved'}
+        keys = {'id', 'title', 'rare_user', 'category', 'publication_date', 'content', 'post_reactions', 'approved', 'post_tags'}
         self.assertEqual(json_response.keys(), keys)
 
     def test_get_all_posts(self):


### PR DESCRIPTION
Added `list` and `create` methods to PostTags View

Supported routes
`/post_tags` Will return serialized JSON objects

## Steps to test
### Postman
1. Pull down the `tp-add-tag-to-post` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Change method to GET using `http://localhost:8000/post_tags`
5. Use the following token:
```
Token 978afa7b76527cc21d76d7b5430ab77f73aa3bff
```
6. The response body should look like:
```
[
    {
        "id": 1,
        "post": 1,
        "tag": 2
    },
    {
        "id": 2,
        "post": 2,
        "tag": 4
    }
]
```
8. You should receive a 204 status
9. This time use a POST request at the url `http://localhost:8000/post_tags` using this request body:
```
{
    "post": 4,
    "tag": 5
}
```
10. You should recieve a 201 Created status code with the following response body:
```
{
    "id": 3,
    "post": 4,
    "tag": 5
}
```

### Integration Test
1. In your terminal run the following code:
```
python3 manage.py test tests -v 1
```
2. Be sure you get the following response back
```
Found 22 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
......................
----------------------------------------------------------------------
Ran 22 tests in 0.452s

OK
Destroying test database for alias 'default'...
```